### PR TITLE
Add macOS-12 to Azure Pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,3 +41,17 @@ jobs:
   - script: |
       ./build/ShowEndOfLineChars
     displayName: $(Agent.JobName) results
+
+- job: macOS12
+  pool:
+    vmImage: 'macOS-12'
+  steps:
+  - script: |
+      mkdir build
+      cd build
+      cmake ..
+      make
+    displayName: $(Agent.JobName) Clang build
+  - script: |
+      ./build/ShowEndOfLineChars
+    displayName: $(Agent.JobName) results


### PR DESCRIPTION
"MacOS 12 Monterey Preview" is the newest MacOS version on a Microsoft hosted virtual machine, according to https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops&tabs=yaml#use-a-microsoft-hosted-agent